### PR TITLE
According to ECMAScript 262, the context argument to every, forEach and ...

### DIFF
--- a/cbuffer.js
+++ b/cbuffer.js
@@ -170,46 +170,25 @@ CBuffer.prototype = {
 	// check every item in the array against a test
 	every : function(callback, context) {
 		var i = 0;
-		if (context) {
-			for (; i < this.size; i++) {
-				if (!callback.call(context, this.data[(this.start + i) % this.length], i, this))
-					return false;
-			}
-		} else {
-			for (; i < this.size; i++) {
-				if (!callback(this.data[(this.start + i) % this.length], i, this))
-					return false;
-			}
+		for (; i < this.size; i++) {
+			if (!callback.call(context, this.data[(this.start + i) % this.length], i, this))
+				return false;
 		}
 		return true;
 	},
 	// loop through each item in buffer
 	forEach : function(callback, context) {
 		var i = 0;
-		// check if context was passed
-		if (context) {
-			for (; i < this.size; i++) {
-				callback.call(context, this.data[(this.start + i) % this.length], i, this);
-			}
-		} else {
-			for (; i < this.size; i++) {
-				callback(this.data[(this.start + i) % this.length], i, this);
-			}
+		for (; i < this.size; i++) {
+			callback.call(context, this.data[(this.start + i) % this.length], i, this);
 		}
 	},
 	// check items agains test until one returns true
 	some : function(callback, context) {
 		var i = 0;
-		if (context) {
-			for (; i < this.size; i++) {
-				if (callback.call(context, this.data[(this.start + i) % this.length], i, this))
-					return true;
-			}
-		} else {
-			for (; i < this.size; i++) {
-				if (callback(this.data[(this.start + i) % this.length], i, this))
-					return true;
-			}
+		for (; i < this.size; i++) {
+			if (callback.call(context, this.data[(this.start + i) % this.length], i, this))
+				return true;
 		}
 		return false;
 	},


### PR DESCRIPTION
According to [ECMAScript 262](http://www.ecma-international.org/ecma-262/5.1/#sec-15.4.4.18), the _context_ argument to **every**, **forEach** and **some** should be _undefined_ if not supplied. As an named argument, not supplied to a function is always _undefined_ there should be no need to check that argument for a falsy value. Hence the function should run in an _undefined_ context which in turn means it will run in the global context, which the caller code should be ignorant of as no context was supplied. <- CBuffer argumentation ;)
I have removed the extraneous code but found no tests to verify that CBuffer hasn't changed behavior other than my sane thinking think it should not. 
