### PR TITLE
Adds error message to ensure a valid buffer object after initialization

### DIFF
--- a/cbuffer.js
+++ b/cbuffer.js
@@ -5,7 +5,7 @@ function CBuffer() {
 	if (!(this instanceof CBuffer)) {
 		// multiple conditions need to be checked to properly emulate Array
 		if (arguments.length > 1 || typeof arguments[0] !== 'number') {
-			return CBuffer.apply(new CBuffer(), arguments);
+			return CBuffer.apply(new CBuffer(arguments.length), arguments);
 		} else {
 			return new CBuffer(arguments[0]);
 		}

--- a/test/core/cbuffer-test.js
+++ b/test/core/cbuffer-test.js
@@ -1,5 +1,5 @@
 var vows = require('vows'),
-    assert = require('assert')
+    assert = require('assert'),
     suite = vows.describe('CBuffer'),
     und = undefined;
 
@@ -16,6 +16,10 @@ suite.addBatch({
 			assert.isTrue((new CBuffer(1, 2, 3)) instanceof CBuffer);
 			assert.isTrue(CBuffer(1, 2, 3) instanceof CBuffer);
 			assert.isTrue(CBuffer(1).constructor === CBuffer);
+		},
+		'Missing argument exception': function () {
+			assert.throws(function () { CBuffer(); }, Error);
+			assert.throws(function () { new CBuffer(); }, Error);
 		},
 		'data' : function (CBuffer) {
 			assert.deepEqual(CBuffer(3).data, [,,]);


### PR DESCRIPTION
Otherwise if a user would init a CBuffer like

`var buffer = new CBuffer()`

he would get a "bad" object which would throw less meaningful error messages like

`TypeError: Cannot set property 'NaN' of undefined` on `buffer.push(0)`
