### PR TITLE
sortedIndex should capture from 0 to size on non full buffers

### DIFF
--- a/cbuffer.js
+++ b/cbuffer.js
@@ -174,8 +174,9 @@ CBuffer.prototype = {
 	// is a sorted circular buffer
 	sortedIndex : function(value, comparitor, context) {
 		comparitor = comparitor || defaultComparitor;
-		var low = this.start,
-			high = this.size - 1;
+		var isFull = this.length === this.size,
+			low = this.start,
+			high = isFull ? this.size - 1 : this.size;
 
 		// Tricky part is finding if its before or after the pivot
 		// we can get this info by checking if the target is less than
@@ -189,8 +190,9 @@ CBuffer.prototype = {
 		  if (comparitor.call(context, value, this.data[mid]) > 0) low = mid + 1;
 		  else high = mid;
 		}
-		// http://stackoverflow.com/a/18618273/1517919
-		return (((low - this.start) % this.size) + this.size) % this.size;
+		return !isFull ? low :
+			// http://stackoverflow.com/a/18618273/1517919
+			(((low - this.start) % this.size) + this.size) % this.size;
 	},
 
 	/* iteration methods */

--- a/test/accessor/sortedIndex-test.js
+++ b/test/accessor/sortedIndex-test.js
@@ -40,6 +40,12 @@ suite.addBatch({
 				'works with partially complete buffers': function(buffer) {
 					assert.equal(buffer.sortedIndex(3), 2);
 					assert.equal(buffer.sortedIndex(8), 7);
+				},
+				'can determine postion in a fixed length buffer': function(buffer) {
+					assert.equal(buffer.sortedIndex(0), 0);
+					assert.equal(buffer.sortedIndex(1), 0);
+					assert.equal(buffer.sortedIndex(3), 2);
+					assert.equal(buffer.sortedIndex(10), 8);
 				}
 			},
 
@@ -90,8 +96,6 @@ suite.addBatch({
 				}
 			}
 		}
-
-
 	}
 });
 


### PR DESCRIPTION
This was an annoying edge case I ran into where

Currently
```js
var buffer = CBuffer(20);
buffer.push(1, 2, 3, 4, 5, 6, 7, 8);
buffer.sortedIndex(10); // 7
buffer.push(10);
buffer.indexOf(10); //8
```