### PR TITLE
Added map and join methods. Also made negative indices work for get

### DIFF
--- a/cbuffer.js
+++ b/cbuffer.js
@@ -217,15 +217,15 @@ CBuffer.prototype = {
 			callback.call(context, this.data[(this.start + i) % this.size], i, this);
 		}
 	},
-  // construct new CBuffer of same length, apply map function, and return new CBuffer
-  map : function (callback, context) {
-    var outCBuffer = new CBuffer(this.size);
-    for (var i = 0; i < this.length; i++) {
-      var n = (this.start + i) % this.size;
-      outCBuffer.push(callback.call(context, this.data[n], i, this));
-    }
-    return outCBuffer;
-  },
+	// construct new CBuffer of same length, apply map function, and return new CBuffer
+	map : function (callback, context) {
+		var outCBuffer = new CBuffer(this.size);
+		for (var i = 0; i < this.length; i++) {
+			var n = (this.start + i) % this.size;
+			outCBuffer.push(callback.call(context, this.data[n], i, this));
+		}
+		return outCBuffer;
+	},
 	// check items agains test until one returns true
 	// TODO: figure out how to emulate Array use better
 	some : function (callback, context) {
@@ -305,16 +305,16 @@ CBuffer.prototype = {
 	toArray : function () {
 		return this.slice();
 	},
-  // return a string based on the array
-  join : function(separator) {
-    if (!separator) separator = ',';
-    var outString = new String(this.data[0]);
-    for (var i = 1; i < this.length; i++) {
-      var n = (this.start + i) % this.size;
-      outString = outString.concat(separator, this.data[i]);
-    }
-    return outString;
-  },
+	// return a string based on the array
+	join : function(separator) {
+		if (!separator) separator = ',';
+		var outString = new String(this.data[0]);
+		for (var i = 1; i < this.length; i++) {
+			var n = (this.start + i) % this.size;
+			outString = outString.concat(separator, this.data[i]);
+		}
+		return outString;
+	},
 	// slice the buffer to an arraay
 	slice : function (start, end) {
 		var size = this.length;

--- a/cbuffer.js
+++ b/cbuffer.js
@@ -34,6 +34,10 @@ function defaultComparitor(a, b) {
 	return a == b ? 0 : a > b ? 1 : -1;
 }
 
+function mod(n, m) {
+  return ((n % m) + m) % m;
+}
+
 CBuffer.prototype = {
 	// properly set constructor
 	constructor : CBuffer,
@@ -213,8 +217,17 @@ CBuffer.prototype = {
 			callback.call(context, this.data[(this.start + i) % this.size], i, this);
 		}
 	},
+  // construct new CBuffer of same length, apply map function, and return new CBuffer
+  map : function (callback, context) {
+    var outCBuffer = new CBuffer(this.size);
+    for (var i = 0; i < this.length; i++) {
+      var n = (this.start + i) % this.size;
+      outCBuffer.push(callback.call(context, this.data[n], i, this));
+    }
+    return outCBuffer;
+  },
 	// check items agains test until one returns true
-	// TODO: figure out how to emuldate Array use better
+	// TODO: figure out how to emulate Array use better
 	some : function (callback, context) {
 		var i = 0;
 		for (; i < this.length; i++) {
@@ -279,7 +292,7 @@ CBuffer.prototype = {
 	},
 	// return specific index in buffer
 	get : function (arg) {
-		return this.data[(this.start + arg) % this.size];
+		return this.data[mod(this.start + arg, this.size)];
 	},
 	isFull : function (arg) {
 		return this.size === this.length;
@@ -292,6 +305,16 @@ CBuffer.prototype = {
 	toArray : function () {
 		return this.slice();
 	},
+  // return a string based on the array
+  join : function(separator) {
+    if (!separator) separator = ',';
+    var outString = new String(this.data[0]);
+    for (var i = 1; i < this.length; i++) {
+      var n = (this.start + i) % this.size;
+      outString = outString.concat(separator, this.data[i]);
+    }
+    return outString;
+  },
 	// slice the buffer to an arraay
 	slice : function (start, end) {
 		var size = this.length;

--- a/test/iterator/map-test.js
+++ b/test/iterator/map-test.js
@@ -1,0 +1,37 @@
+var vows = require('vows'),
+    assert = require('assert')
+    suite = vows.describe('CBuffer');
+
+require('../env.js');
+
+suite.addBatch({
+	'map' : {
+		'topic' : function () {
+			return CBuffer;
+		},
+		'map' : function (CBuffer) {
+			var tmp, tmp2, tmp3, tmp4;
+      tmp = new CBuffer(1, 2, 3, 4);
+      tmp2 = tmp.map(function timesTwo(val) { return val * 2; });
+      assert.ok (tmp2 instanceof CBuffer);
+      assert.equal (tmp2.get(0), 2);
+      assert.equal (tmp2.get(1), 4);
+      assert.equal (tmp2.get(2), 6);
+      assert.equal (tmp2.get(3), 8);
+
+      tmp3 = tmp.map(function timesI(val, i) { return val * i; });
+      assert.equal (tmp3.get(0), 0);
+      assert.equal (tmp3.get(1), 2);
+      assert.equal (tmp3.get(2), 6);
+      assert.equal (tmp3.get(3), 12);
+
+      tmp4 = tmp.map(function timesPrevious(val, i, cbuf) { return val * cbuf.get(i - 1); });
+      assert.equal (tmp4.get(0), 4);
+      assert.equal (tmp4.get(1), 2);
+      assert.equal (tmp4.get(2), 6);
+      assert.equal (tmp4.get(3), 12);
+		}
+	}
+});
+
+suite.export(module);

--- a/test/iterator/map-test.js
+++ b/test/iterator/map-test.js
@@ -11,25 +11,25 @@ suite.addBatch({
 		},
 		'map' : function (CBuffer) {
 			var tmp, tmp2, tmp3, tmp4;
-      tmp = new CBuffer(1, 2, 3, 4);
-      tmp2 = tmp.map(function timesTwo(val) { return val * 2; });
-      assert.ok (tmp2 instanceof CBuffer);
-      assert.equal (tmp2.get(0), 2);
-      assert.equal (tmp2.get(1), 4);
-      assert.equal (tmp2.get(2), 6);
-      assert.equal (tmp2.get(3), 8);
+			tmp = new CBuffer(1, 2, 3, 4);
+			tmp2 = tmp.map(function timesTwo(val) { return val * 2; });
+			assert.ok (tmp2 instanceof CBuffer);
+			assert.equal (tmp2.get(0), 2);
+			assert.equal (tmp2.get(1), 4);
+			assert.equal (tmp2.get(2), 6);
+			assert.equal (tmp2.get(3), 8);
 
-      tmp3 = tmp.map(function timesI(val, i) { return val * i; });
-      assert.equal (tmp3.get(0), 0);
-      assert.equal (tmp3.get(1), 2);
-      assert.equal (tmp3.get(2), 6);
-      assert.equal (tmp3.get(3), 12);
+			tmp3 = tmp.map(function timesI(val, i) { return val * i; });
+			assert.equal (tmp3.get(0), 0);
+			assert.equal (tmp3.get(1), 2);
+			assert.equal (tmp3.get(2), 6);
+			assert.equal (tmp3.get(3), 12);
 
-      tmp4 = tmp.map(function timesPrevious(val, i, cbuf) { return val * cbuf.get(i - 1); });
-      assert.equal (tmp4.get(0), 4);
-      assert.equal (tmp4.get(1), 2);
-      assert.equal (tmp4.get(2), 6);
-      assert.equal (tmp4.get(3), 12);
+			tmp4 = tmp.map(function timesPrevious(val, i, cbuf) { return val * cbuf.get(i - 1); });
+			assert.equal (tmp4.get(0), 4);
+			assert.equal (tmp4.get(1), 2);
+			assert.equal (tmp4.get(2), 6);
+			assert.equal (tmp4.get(3), 12);
 		}
 	}
 });

--- a/test/utility/join-test.js
+++ b/test/utility/join-test.js
@@ -1,0 +1,25 @@
+var vows = require('vows'),
+	assert = require('assert'),
+	suite = vows.describe('CBuffer');
+
+require('../env');
+
+suite.addBatch({
+	'join': {
+		topic: function() {
+			return CBuffer(1, 3, 5, 7, 11);
+		},
+		'no arguments returns comma-separated string': function(buffer) {
+			assert.equal(buffer.join(), '1,3,5,7,11');
+      assert.equal(buffer.join(), [1, 3, 5, 7, 11].join());
+		},
+		'handles custom join string': function(buffer) {
+      assert.equal(buffer.join(', '), '1, 3, 5, 7, 11');
+		},
+		'handles join argument that is not a string': function(buffer) {
+      assert.equal(buffer.join(true), '1true3true5true7true11');
+		}
+	}
+});
+
+suite.export(module);

--- a/test/utility/join-test.js
+++ b/test/utility/join-test.js
@@ -11,13 +11,13 @@ suite.addBatch({
 		},
 		'no arguments returns comma-separated string': function(buffer) {
 			assert.equal(buffer.join(), '1,3,5,7,11');
-      assert.equal(buffer.join(), [1, 3, 5, 7, 11].join());
+			assert.equal(buffer.join(), [1, 3, 5, 7, 11].join());
 		},
 		'handles custom join string': function(buffer) {
-      assert.equal(buffer.join(', '), '1, 3, 5, 7, 11');
+			assert.equal(buffer.join(', '), '1, 3, 5, 7, 11');
 		},
 		'handles join argument that is not a string': function(buffer) {
-      assert.equal(buffer.join(true), '1true3true5true7true11');
+			assert.equal(buffer.join(true), '1true3true5true7true11');
 		}
 	}
 });


### PR DESCRIPTION
Hi, thanks for getting this project started for a circular buffer with an Array interface!

For my own usage, I needed `map` and `join`, so at first I just did a `toArray()` and did them, but would prefer eliminating the extra temporary object, so I've implemented the parts I need and wrote tests for them.

While writing the tests I noticed that the `get` function doesn't allow negative indexing, which seems useful for Circular Buffers in a way that it wouldn't be for a normal Array, so I also added a negative-capable modulus function and used it there.